### PR TITLE
Use `bindings` for `require`ing the binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var binding = require('./build/Release/binding');
+var binding = require('bindings')('binding');
 
 module.exports = function (uid) {
 	if (uid === undefined) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "bindings": "^1.2.1",
     "nan": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Prevents 'Cannot find module' when used with debug build of node (which
puts the binding at `./build/Debug/binding.node` instead of
`./build/Release/binding.node`) and handles other corner cases.
